### PR TITLE
Improved addon lookup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ repositories {
     maven { url 'https://repo.destroystokyo.com/repository/maven-public/' }
     maven { url 'https://papermc.io/repo/repository/maven-public/' }
     maven { url 'https://jitpack.io' }
+    maven { url 'https://repo.skriptlang.org/releases' }
 }
 
 dependencies {

--- a/src/main/kotlin/net/skripthub/docstool/documentation/BuildDocs.kt
+++ b/src/main/kotlin/net/skripthub/docstool/documentation/BuildDocs.kt
@@ -285,15 +285,31 @@ class BuildDocs(private val instance: JavaPlugin, private val sender: CommandSen
 
         // If null, bail and throw error
         return addonMap.entries
-                .firstOrNull { name.startsWith(it.key) }
-                ?.value
+                .firstOrNull {
+                    var key = it.key
+                    while (key.contains('.')) {
+                        if (name.startsWith(key))
+                            return@firstOrNull true
+                        key = key.substring(0, key.lastIndexOf('.'))
+                    }
+                    return@firstOrNull false
+                }
+            ?.value
     }
 
     private fun getAddon(c: Class<*>): AddonData? {
         val name = c.`package`.name
         // If null, bail and throw error
         return addonMap.entries
-                .firstOrNull { name.startsWith(it.key) }
+                .firstOrNull {
+                    var key = it.key
+                    while (key.contains('.')) {
+                        if (name.startsWith(key))
+                            return@firstOrNull true
+                        key = key.substring(0, key.lastIndexOf('.'))
+                    }
+                    return@firstOrNull false
+                }
                 ?.value
     }
 }


### PR DESCRIPTION
Some addons/plugins have the JavaPlugin class in a non-root package, for example:
`com.alessiodp.project.bukkit.bootstrap` and skripts located in `com.alessiodp.project.bukkit.skripts`.

With this change it will iterate for the parent package until it reaches the root:
`com.alessiodp.project.bukkit.bootstrap` > `com.alessiodp.bukkit.project` > `com.alessiodp.bukkit` > `com.alessiodp`