### PR TITLE
Fix repeatable example annotation

### DIFF
--- a/src/main/kotlin/net/skripthub/docstool/documentation/GenerateSyntax.kt
+++ b/src/main/kotlin/net/skripthub/docstool/documentation/GenerateSyntax.kt
@@ -1,5 +1,6 @@
 package net.skripthub.docstool.documentation
 
+import ch.njol.skript.Skript
 import ch.njol.skript.classes.Changer.ChangeMode
 import ch.njol.skript.classes.ClassInfo
 import ch.njol.skript.doc.*
@@ -248,8 +249,8 @@ class GenerateSyntax {
             // Examples is the classic example annotation
 
             val combinedExamples = ArrayList<String?>()
-            combinedExamples.addAll(grabRepeatableAnnotation(syntaxInfoClass, Example::class.java, { it.value }))
             grabAnnotation(syntaxInfoClass, Examples::class.java, { it.value })?.toCollection(combinedExamples)
+            grabAnnotation(syntaxInfoClass, Example.Examples::class.java, { it.value.map { example -> example.value } })?.toCollection(combinedExamples)
 
             return if (combinedExamples.filterNotNull().isEmpty()) null else cleanHTML(combinedExamples.filterNotNull().toTypedArray())
         }
@@ -315,12 +316,6 @@ class GenerateSyntax {
             return supplier.apply(source.getAnnotation(annotation)) ?: default
         }
 
-        private inline fun <A : Annotation, reified R> grabRepeatableAnnotation(source: Class<*>, annotation: Class<A>, supplier: Function<A, R?>, default: R? = null): Array<R?> {
-            if (!source.isAnnotationPresent(annotation)) return arrayOf(default)
-            return source.getAnnotationsByType(annotation)
-                .map { supplier.apply(it) }
-                .toTypedArray()
-        }
-
     }
+
 }

--- a/src/main/kotlin/net/skripthub/docstool/documentation/GenerateSyntax.kt
+++ b/src/main/kotlin/net/skripthub/docstool/documentation/GenerateSyntax.kt
@@ -1,6 +1,5 @@
 package net.skripthub.docstool.documentation
 
-import ch.njol.skript.Skript
 import ch.njol.skript.classes.Changer.ChangeMode
 import ch.njol.skript.classes.ClassInfo
 import ch.njol.skript.doc.*


### PR DESCRIPTION
This PR aims to fix an issue with my previous implementation of repeatable annotations, turns out `getAnnotationsByType` despite saying it'll attempt searching for all repeated variants, it instead just ignores it if there's more than one.

I should of tested it, that's on me, this one has been tested to ensure it's working as intended, I believe it's not the method's fault but just caused by skript's implementation of handling repeated annotations.

Before
![image](https://github.com/user-attachments/assets/ca109e32-bc59-4934-826b-3d90f6c363f9)

After
![image](https://github.com/user-attachments/assets/fc174c5f-9586-4e65-a035-3a988a040ce2)
